### PR TITLE
Remove useless test

### DIFF
--- a/tests/testFactorIntoPrimes.cpp
+++ b/tests/testFactorIntoPrimes.cpp
@@ -72,7 +72,3 @@ TEST(SumOfFactors, Sum_is_computed_properly){
     checkSumForNumber(9, 6);
     checkSumForNumber(2*3*5*13*31, 2+3+5+13+31);
 }
-
-TEST(SumOfFactors, Sum_for_up_to_a_number_is_computed_properly){
-    pf.factor(2);
-}


### PR DESCRIPTION
Sum for up to a number in testFactorInto Primes was completely useless.
Some cleaning up.
